### PR TITLE
Enable passing an 'ensure' parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,12 +3,16 @@
 #
 # Examples
 #
-#   include macvim
-class macvim {
+#   class { 'macvim':
+#     ensure => 'latest',
+#   }
+class macvim (
+  $ensure = 'installed'
+) {
   case $::osfamily {
     'Darwin': {
       package { 'macvim':
-        ensure          => installed,
+        ensure          => $ensure,
         install_options => [
           '--with-cscope',
           '--override-system-vim',

--- a/spec/classes/macvim_spec.rb
+++ b/spec/classes/macvim_spec.rb
@@ -3,11 +3,25 @@ require "spec_helper"
 describe "macvim" do
   let(:facts) { default_test_facts }
 
-  it do
-    should contain_class("macvim")
-    should contain_package("macvim").with({
-      :ensure          => "installed",
-      :install_options => ['--with-cscope','--override-system-vim']
-    })
+  describe "default" do
+    it do
+      should contain_class("macvim")
+      should contain_package("macvim").with({
+        :ensure          => "installed",
+        :install_options => ['--with-cscope','--override-system-vim']
+      })
+    end
   end
+
+  describe "ensure" do
+    let(:params) {{:ensure => 'latest'}}
+    it do
+      should contain_class("macvim")
+      should contain_package("macvim").with({
+        :ensure          => "latest",
+        :install_options => ['--with-cscope','--override-system-vim']
+      })
+    end
+  end
+
 end


### PR DESCRIPTION
Makes it easier to have Boxen automatically keep your MacVim updated.
